### PR TITLE
change empty string check to be backward-compatile with Java 1.5 [0]

### DIFF
--- a/core/src/visad/java3d/DisplayRendererJ3D.java
+++ b/core/src/visad/java3d/DisplayRendererJ3D.java
@@ -1068,7 +1068,7 @@ public abstract class DisplayRendererJ3D
     	Enumeration strings = getCursorStringVector().elements();
     	while (strings.hasMoreElements()) {
     		String string = (String) strings.nextElement();
-    		if ((string != null) && (! string.trim().isEmpty())) {
+    		if ((string != null) && (! (string.length() == 0))) {
     			try {
     				VisADLineArray array =
     						PlotText.render_label(string, start, base, up, false);


### PR DESCRIPTION
Fix for pre-release testing error on 19 Aug 2013.
