### PR TITLE
separte font size scaling factor from autoscale adjustment scaling

### DIFF
--- a/core/src/visad/TextControl.java
+++ b/core/src/visad/TextControl.java
@@ -45,6 +45,10 @@ public class TextControl extends Control {
 
   private double size = 1.0;
 
+  private double factor = 1.0;
+
+  private double autoSizeFactor = 1.0;
+
   // WLH 31 May 2000
   // draw on sphere surface
   private boolean sphere = false;
@@ -265,10 +269,18 @@ public class TextControl extends Control {
   /** set the size of characters; the default is 1.0 */
   public void setSize(double s)
          throws VisADException, RemoteException {
-    size = s;
+    factor = s;
+    size = factor*autoSizeFactor;
     changeControl(true);
   }
 
+  private void setSizeForAuto(double autoSizeFactor)
+          throws VisADException, RemoteException {
+    this.autoSizeFactor = autoSizeFactor;
+    size = factor*autoSizeFactor;
+    changeControl(true);
+  }
+  
   /** return the size */
   public double getSize() {
     return size;
@@ -604,7 +616,6 @@ public class TextControl extends Control {
     private TextControl text_control;
     private double base_scale = 1.0;
     private float last_cscale = 1.0f;
-    private double base_size = 1.0;
     private boolean active = false;
 
     ProjectionControlListener(MouseBehavior m, TextControl t,
@@ -631,14 +642,13 @@ public class TextControl extends Control {
         pfirst = false;
         base_scale = scale[2];
         last_cscale = 1.0f;
-        base_size = text_control.getSize();
       }
       else {
         float cscale = (float) (base_scale / scale[2]);
         float ratio = cscale / last_cscale;
         if (ratio < 0.95f || 1.05f < ratio) {
           last_cscale = cscale;
-          text_control.setSize(base_size * cscale);
+          text_control.setSizeForAuto(cscale);
         }
       }
     }


### PR DESCRIPTION
factor: new private method: setSizeForAuto is now called in the
ProjectionControlListener which sets these independently and
then calls TextControl.changeControl.
