### PR TITLE
option to angle label away from the axis or not

### DIFF
--- a/core/src/visad/AxisScale.java
+++ b/core/src/visad/AxisScale.java
@@ -92,6 +92,9 @@ public class AxisScale implements java.io.Serializable
   private int tickOrient = PRIMARY;
   private static final double TICKSIZE = .5;  // major ticks are 1/2 char ht.
   private NumberFormat labelFormat = null;
+  
+  /** Is the label angled away from the axis or is it "flat"*/
+  private boolean labelRelief = true;
 
   /**
    * Construct a new AxisScale for the given ScalarMap
@@ -616,6 +619,10 @@ public class AxisScale implements java.io.Serializable
         up[2] = 0.0;
         startn[2] = 0.0;
         startp[2] = 0.0;
+      }
+      
+      if (!labelRelief ) {
+        up[2] = 0.0;        
       }
   
       // VisADLineArray coordinates have three entries for (x, y, z) of each point
@@ -1726,6 +1733,24 @@ public class AxisScale implements java.io.Serializable
           : PlotText.shortString(value);
     }
     return label;
+  }
+
+  /**
+   * Checks if is label has relief.
+   *
+   * @return true, if is label has relief
+   */
+  public boolean isLabelRelief() {
+    return labelRelief;
+  }
+
+  /**
+   * Sets the label relief.
+   *
+   * @param labelRelief the new label relief
+   */
+  public void setLabelRelief(boolean labelRelief) {
+    this.labelRelief = labelRelief;
   }
 
 }


### PR DESCRIPTION
We have a problem where the axis labels are being obscured by, say, the blue marble. This is because the axis labels are angled down and away from the axis. We would like to have an option where the labels are flat relative to the axis, if you see what I mean. Playing around with the code below allows our axis labels to not be obscured by the blue marble.
