### PR TITLE
Regression to solve spurious lines problem seen on some ATI graphics:

### DIFF
--- a/core/src/visad/java3d/DisplayImplJ3D.java
+++ b/core/src/visad/java3d/DisplayImplJ3D.java
@@ -487,8 +487,11 @@ public class DisplayImplJ3D extends DisplayImpl {
     array.setCapability(GeometryArray.ALLOW_FORMAT_READ);
     array.setCapability(GeometryArray.ALLOW_NORMAL_READ);
     array.setCapability(GeometryArray.ALLOW_TEXCOORD_READ);
+    /* TDR (2013-10-12): Should only be used in conjunction with GeometryArray.updateData 
+       which is not currently implemented
     array.setCapability(GeometryArray.ALLOW_REF_DATA_WRITE);
-    
+    */
+
     // only used when using BY_REFERENCE, so just set it anyways
     //array.setCapability(GeometryArray.ALLOW_REF_DATA_READ);
   }

--- a/core/src/visad/java3d/ShadowTypeJ3D.java
+++ b/core/src/visad/java3d/ShadowTypeJ3D.java
@@ -653,7 +653,9 @@ public abstract class ShadowTypeJ3D extends ShadowType {
     appearance.setCapability(Appearance.ALLOW_TEXGEN_READ);
     appearance.setCapability(Appearance.ALLOW_TEXTURE_ATTRIBUTES_READ);
     appearance.setCapability(Appearance.ALLOW_TEXTURE_READ);
-    appearance.setCapability (Appearance.ALLOW_RENDERING_ATTRIBUTES_WRITE);
+    /* TDR (2013-10-16): Can possibly cause problems on ATI graphics
+    appearance.setCapability(Appearance.ALLOW_RENDERING_ATTRIBUTES_WRITE);
+    */
     // appearance.setCapability(Appearance.ALLOW_TEXTURE_UNIT_STATE_READ);
     appearance.setCapability(Appearance.ALLOW_TRANSPARENCY_ATTRIBUTES_READ);
 
@@ -706,7 +708,9 @@ public abstract class ShadowTypeJ3D extends ShadowType {
     rendering.setCapability(RenderingAttributes.ALLOW_ALPHA_TEST_FUNCTION_READ);
     rendering.setCapability(RenderingAttributes.ALLOW_ALPHA_TEST_VALUE_READ);
     rendering.setCapability(RenderingAttributes.ALLOW_DEPTH_ENABLE_READ);
+    /* TDR (2013-10-16): Can possibly cause problems on ATI graphics
     rendering.setCapability (RenderingAttributes.ALLOW_VISIBLE_WRITE);
+    */
 
     //rendering.setCapability(RenderingAttributes.ALLOW_IGNORE_VERTEX_COLORS_READ
     // );


### PR DESCRIPTION
Don't allow RenderingAttributes WRITE capability.

Don't allow geometry byRef write capabilty: must be used with GeometryArray.updateData
which isn't currently implemented.
