### PR TITLE
Add missing Every Nth range constant [1587]

### DIFF
--- a/core/src/visad/ContourControl.java
+++ b/core/src/visad/ContourControl.java
@@ -47,6 +47,7 @@ public class ContourControl extends Control {
   public static final int LABEL_FREQ_HI = 9;
   
   // default and (somewhat arbitrary) values for labeling every Nth line
+  public static final int EVERY_NTH_MIN = 0;
   public static final int EVERY_NTH_DEFAULT = 2;
   public static final int EVERY_NTH_MAX = 100;
   


### PR DESCRIPTION
Need range min constant to fix bug Bob C found - value of zero (in Contour Properties Editor dialog) should be treated the same as if user toggled labels off.
