### PR TITLE
fix implementation problem with new valueToInterp/valueToGrid signatures

### DIFF
--- a/core/src/visad/Gridded2DSet.java
+++ b/core/src/visad/Gridded2DSet.java
@@ -376,6 +376,10 @@ System.out.println("1st = " + ( (v10[0]-v00[0])*(v11[1]-v10[1])
       throw new SetException("Gridded2DSet.valueToGrid: requires all grid " +
                              "dimensions to be > 1");
     }
+    if (guess != null && guess.length != 2) {
+      throw new SetException("Gridded2DSet.valueToGrid: guess length " 
+          + guess.length + " must equal 2");
+    }
     int length = Math.min(value[0].length, value[1].length);
     float[][] grid = new float[ManifoldDimension][length];
 

--- a/core/src/visad/Gridded3DSet.java
+++ b/core/src/visad/Gridded3DSet.java
@@ -1074,6 +1074,10 @@ public class Gridded3DSet extends GriddedSet {
       throw new SetException("Gridded3DSet.valueToGrid: requires all grid "
           + "dimensions to be > 1");
     }
+    if (guess != null && guess.length != 3) {
+      throw new SetException("Gridded3DSet.valueToGrid: guess length " 
+          + guess.length + " must equal 3");
+    }
     // Avoid any ArrayOutOfBounds exceptions by taking the shortest length
     int length = Math.min(value[0].length, value[1].length);
     length = Math.min(length, value[2].length);
@@ -1083,7 +1087,13 @@ public class Gridded3DSet extends GriddedSet {
     int gx = (LengthX-1)/2; 
     int gy = (LengthY-1)/2; 
     int gz = (LengthZ-1)/2;
-
+    
+    // TDR: special check if i==0 when a first value guess is supplied.
+    if (guess != null && guess[0] >= 0 && guess[1] >= 0 && guess[2] >= 0) {
+      gx = guess[0];
+      gy = guess[1];
+      gz = guess[2];
+    }
 
     float[] A = new float[3];
     float[] B = new float[3];

--- a/core/src/visad/GriddedSet.java
+++ b/core/src/visad/GriddedSet.java
@@ -347,7 +347,7 @@ public class GriddedSet extends SampledSet implements GriddedSetIface {
       A guess for for the first value may be supplied: useful when making
       repeated calls with one value on this set if the resulting grid coords are
       in proximity with one another. The last determined grid location becomes the guess.
-      */
+  */   
   public float[][] valueToGrid(float[][] value, int[] guess) throws VisADException {
     if (Length > 1) {
       for (int j=0; j<DomainDimension; j++) {
@@ -357,13 +357,21 @@ public class GriddedSet extends SampledSet implements GriddedSetIface {
         }
       }
     }
-    throw new UnimplementedException("GriddedSet.valueToGrid");
+    throw new UnimplementedException("GriddedSet.valueToGrid with supplied guess");
   }
   
   /** transform an array of values in R^DomainDimension to an array
       of non-integer grid coordinates */
   public float[][] valueToGrid(float[][] value) throws VisADException {
-    return valueToGrid(value, null);
+    if (Length > 1) {
+      for (int j=0; j<DomainDimension; j++) {
+        if (Lengths[j] < 2) {
+          throw new SetException("GriddedSet.valueToGrid: requires all grid " +
+                                 "dimensions to be > 1");
+        }
+      }
+    }
+    throw new UnimplementedException("GriddedSet.valueToGrid");      
   }
   
   /** for each of an array of values in R^DomainDimension, compute an array
@@ -397,8 +405,22 @@ public class GriddedSet extends SampledSet implements GriddedSetIface {
                              " doesn't match value[0] length " +
                              value[0].length);
     }
-    float[][] grid = valueToGrid(value, guess); // convert value array to grid coord array
-
+    if (guess != null && guess.length != length) {
+      throw new SetException("GriddedSet.valueToInterp: guess length " +
+                             guess.length +
+                             " not equal to Domain dimension " +
+                             DomainDimension);
+    }
+    
+    float[][] grid;
+    // convert value array to grid coord array
+    if (guess != null) {
+      grid = valueToGrid(value, guess);
+    }
+    else {
+      grid = valueToGrid(value);
+    }
+    
     int i, j, k; // loop indices
     int lis; // temporary length of is & cs
     int length_is; // final length of is & cs, varies by i


### PR DESCRIPTION
New signature taking a guess as an argument is currently only implemented for Gridded2D/3DSet. Existing uses of these methods should not be affected. New signatures are particularly useful with repeated calls to the same Set locating a single point on a relatively smooth path. 