### PR TITLE
Fix problem with getting machine's current IP address.

### DIFF
--- a/core/src/edu/wisc/ssec/mcidas/adde/AddeURLConnection.java
+++ b/core/src/edu/wisc/ssec/mcidas/adde/AddeURLConnection.java
@@ -681,8 +681,7 @@ public class AddeURLConnection extends URLConnection
     dos.writeInt(compressionType);   // DRM 03-Mar-2001
 
     // client IP address
-    InetAddress lh = InetAddress.getLocalHost();
-    ipa = lh.getAddress();
+    ipa = t.getLocalAddress().getAddress();
     dos.write(ipa, 0, ipa.length);
 
     // gotta send 4 user bytes, ADDE protocol expects it


### PR DESCRIPTION
On my Linux machine, the hostname will stay the same regardless of the network I'm on, while macOS will change the hostname according to the whims of DHCP. This behavior is especially noticeable when hopping between wifi networks.

This leads to VisAD attempting to resolve a potentially invalid hostname in an apparent effort to get the current IP (note: not the same thing as loopback/localhost). The commit simply grabs the local address from the extant Socket.

I've tried this on both macOS and Linux and there were no problems, though the pull request should remain unmerged so that we can check Windows.
